### PR TITLE
enable punchblock to split inner nodes of fallback text

### DIFF
--- a/lib/punchblock/translator/asterisk/component/output.rb
+++ b/lib/punchblock/translator/asterisk/component/output.rb
@@ -41,7 +41,7 @@ module Punchblock
                 doc.value.children.each do |node|
                   case node
                   when RubySpeech::SSML::Audio
-                    playback([path_for_audio_node(node)]) || render_with_unimrcp(fallback_doc(doc, node))
+                    playback([path_for_audio_node(node)]) || play_fallback(doc, node)
                   when String
                     if node.include?(' ')
                       render_with_unimrcp(copied_doc(doc, node))
@@ -149,9 +149,16 @@ module Punchblock
             @call.channel_var('PLAYBACKSTATUS') != 'FAILED'
           end
 
-          def fallback_doc(original, failed_audio_node)
-            children = failed_audio_node.nokogiri_children
-            copied_doc original, children
+          def play_fallback(original, failed_audio_node)
+            fallback_docs(original, failed_audio_node).each do |part|
+              render_with_unimrcp(part)
+            end
+          end
+
+          def fallback_docs(original, failed_audio_node)
+            failed_audio_node.nokogiri_children.map do |child|
+              copied_doc original, child
+            end
           end
 
           def copied_doc(original, elements)

--- a/spec/punchblock/translator/asterisk/component/output_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/output_spec.rb
@@ -1273,6 +1273,53 @@ module Punchblock
                       original_command.complete_event(0.1).reason.should be_a Punchblock::Component::Output::Complete::Finish
                     end
 
+                    context "when multiple fallback documents are specified" do
+                      let :fallback_doc1 do
+                        RubySpeech::SSML.draw do
+                          voice(name:'Paul'){ prosody(rate: 1.0){ 'Fallback 1' }}
+                        end
+                      end
+
+                      let :fallback_doc2 do
+                        RubySpeech::SSML.draw do
+                          voice(name:'Paul'){ prosody(rate: 1.0){ 'Fallback 2' }}
+                        end
+                      end
+
+                      let :fallback_doc do
+                        RubySpeech::SSML.draw do
+                          voice(name:'Paul'){ prosody(rate: 1.0){ 'Fallback 1' }}
+                          voice(name:'Paul'){ prosody(rate: 1.0){ 'Fallback 2' }}
+                        end
+                      end
+
+                      let :ssml_doc do
+                        my_fallback_doc = fallback_doc
+                        RubySpeech::SSML.draw do
+                          audio :src => audio_filename1 do
+                            string "Fallback 1"
+                          end
+                          audio :src => audio_filename2 do
+                            embed my_fallback_doc
+                          end
+                          audio :src => audio_filename3 do
+                            string "Fallback 3"
+                          end
+                        end
+                      end
+
+                      it "should render each document individually via MRCP and then send a complete event" do
+                        expect_answered
+                        expect_playback audio_filename1
+                        expect_playback audio_filename2
+                        expect_mrcpsynth fallback_doc1
+                        expect_mrcpsynth fallback_doc2
+                        expect_playback audio_filename3
+                        subject.execute
+                        original_command.complete_event(0.1).reason.should be_a Punchblock::Component::Output::Complete::Finish
+                      end
+                    end
+
                     context "and the SYNTHSTATUS variable is set to 'ERROR'" do
                       let(:synthstatus) { 'ERROR' }
 


### PR DESCRIPTION
this handles our long tts edgecase for fallback text

Files updated:
- lib/punchblock/translator/asterisk/component/output.rb
- spec/punchblock/translator/asterisk/component/output_spec.rb
