### PR TITLE
Fix Test Suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [ifbyphone-develop]
+  * Bugfix: Register/lookup components by their full URI rather than component ID since the component ID may only be unique per call (cherry-pick from mainline)
+  * Bugfix: Hold back Virtus dependency to avoid API-breaking changes (cherry-pick from mainline)
+
 # [develop](https://github.com/adhearsion/punchblock)
   * Feature: Support RubySpeech builtin grammars on Asterisk and FreeSWITCH
   * Bugfix: Reject commands against components which have finished on Asterisk, and garbage collect them

--- a/punchblock.gemspec
+++ b/punchblock.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency %q<ruby_ami>, ["~> 2.0"]
   s.add_runtime_dependency %q<ruby_fs>, ["~> 1.1"]
   s.add_runtime_dependency %q<ruby_speech>, ["~> 2.3"]
-  s.add_runtime_dependency %q<virtus>
+  s.add_runtime_dependency %q<virtus>, ["~> 0.5"]
   s.add_runtime_dependency %q<ruby_jid>, ["~> 1.0"]
 
   s.add_development_dependency %q<bundler>, ["~> 1.0"]


### PR DESCRIPTION
Pull in Punchblock fix for Virtus dependency. I believe @runningferret has already locked Virtus on our application, so this change will only affect the test output.
