### PR TITLE
US3463 Construct MRCPPrompt for :native_or_unimrcp recognizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# [ifbyphone-develop]
+# [ifbyphone-develop](https://github.com/cloudvox/punchblock)
   * Bugfix: Register/lookup components by their full URI rather than component ID since the component ID may only be unique per call (cherry-pick from mainline)
   * Bugfix: Hold back Virtus dependency to avoid API-breaking changes (cherry-pick from mainline)
+  * Feature: Support `:native_or_unimrcp` renderer when using `:unimrcp` recognizer for ASR
 
 # [develop](https://github.com/adhearsion/punchblock)
   * Feature: Support RubySpeech builtin grammars on Asterisk and FreeSWITCH

--- a/lib/punchblock/translator/asterisk/call.rb
+++ b/lib/punchblock/translator/asterisk/call.rb
@@ -239,7 +239,7 @@ module Punchblock
             when 'asterisk'
               Component::MRCPNativePrompt
             else
-              raise InvalidCommandError, 'Invalid recognizer/renderer combination'
+              fail InvalidCommandError, 'Invalid recognizer/renderer combination'
             end
           else
             Component::ComposedPrompt

--- a/lib/punchblock/translator/asterisk/call.rb
+++ b/lib/punchblock/translator/asterisk/call.rb
@@ -239,7 +239,7 @@ module Punchblock
             when 'asterisk'
               Component::MRCPNativePrompt
             else
-              fail InvalidCommandError, 'Invalid recognizer/renderer combination'
+              raise InvalidCommandError, 'Invalid recognizer/renderer combination'
             end
           else
             Component::ComposedPrompt

--- a/lib/punchblock/translator/asterisk/call.rb
+++ b/lib/punchblock/translator/asterisk/call.rb
@@ -212,7 +212,19 @@ module Punchblock
           when Punchblock::Component::Input
             execute_component Component::Input, command
           when Punchblock::Component::Prompt
-            component_class = determine_component_class(command)
+            component_class = case command.input.recognizer
+            when 'unimrcp'
+              case command.output.renderer
+              when 'unimrcp', 'native_or_unimrcp'
+                Component::MRCPPrompt
+              when 'asterisk'
+                Component::MRCPNativePrompt
+              else
+                raise InvalidCommandError, 'Invalid recognizer/renderer combination'
+              end
+            else
+              Component::ComposedPrompt
+            end
             execute_component component_class, command
           when Punchblock::Component::Record
             execute_component Component::Record, command
@@ -227,23 +239,6 @@ module Punchblock
           command.response = ProtocolError.new.setup 'error', e.message, id
         rescue Celluloid::DeadActorError
           command.response = ProtocolError.new.setup :item_not_found, "Could not find a component with ID #{command.component_id} for call #{id}", id, command.component_id
-        end
-
-        def determine_component_class(command)
-          if command.input.recognizer === 'unimrcp'
-            case command.output.renderer
-            when 'unimrcp'
-              Component::MRCPPrompt
-            when 'native_or_unimrcp'
-              Component::MRCPPrompt
-            when 'asterisk'
-              Component::MRCPNativePrompt
-            else
-              raise InvalidCommandError, 'Invalid recognizer/renderer combination'
-            end
-          else
-            Component::ComposedPrompt
-          end
         end
 
         #

--- a/lib/punchblock/translator/asterisk/component/mrcp_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_prompt.rb
@@ -11,11 +11,11 @@ module Punchblock
           private
 
           def validate
-            raise OptionError, "The renderer #{renderer} is unsupported." unless renderer == 'unimrcp' or renderer == 'native_or_unimrcp'
-            raise OptionError, "The recognizer #{recognizer} is unsupported." unless recognizer == 'unimrcp' or renderer == 'native_or_unimrcp'
-            raise OptionError, 'An SSML document is required.' unless output_node.render_documents.count > 0
-            raise OptionError, 'Only one document is allowed.' if output_node.render_documents.count > 1
-            raise OptionError, 'A grammar is required.' unless input_node.grammars.count > 0
+            fail OptionError, "The renderer #{renderer} is unsupported." unless renderer == 'unimrcp' || renderer == 'native_or_unimrcp'
+            fail OptionError, "The recognizer #{recognizer} is unsupported." unless recognizer == 'unimrcp' || renderer == 'native_or_unimrcp'
+            fail OptionError, 'An SSML document is required.' unless output_node.render_documents.count > 0
+            fail OptionError, 'Only one document is allowed.' if output_node.render_documents.count > 1
+            fail OptionError, 'A grammar is required.' unless input_node.grammars.count > 0
 
             super
           end

--- a/lib/punchblock/translator/asterisk/component/mrcp_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_prompt.rb
@@ -11,8 +11,8 @@ module Punchblock
           private
 
           def validate
-            raise OptionError, "The renderer #{renderer} is unsupported." unless renderer == 'unimrcp'
-            raise OptionError, "The recognizer #{recognizer} is unsupported." unless recognizer == 'unimrcp'
+            raise OptionError, "The renderer #{renderer} is unsupported." unless renderer == 'unimrcp' or renderer == 'native_or_unimrcp'
+            raise OptionError, "The recognizer #{recognizer} is unsupported." unless recognizer == 'unimrcp' or renderer == 'native_or_unimrcp'
             raise OptionError, 'An SSML document is required.' unless output_node.render_documents.count > 0
             raise OptionError, 'Only one document is allowed.' if output_node.render_documents.count > 1
             raise OptionError, 'A grammar is required.' unless input_node.grammars.count > 0

--- a/lib/punchblock/translator/asterisk/component/mrcp_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_prompt.rb
@@ -11,11 +11,11 @@ module Punchblock
           private
 
           def validate
-            fail OptionError, "The renderer #{renderer} is unsupported." unless renderer == 'unimrcp' || renderer == 'native_or_unimrcp'
-            fail OptionError, "The recognizer #{recognizer} is unsupported." unless recognizer == 'unimrcp' || renderer == 'native_or_unimrcp'
-            fail OptionError, 'An SSML document is required.' unless output_node.render_documents.count > 0
-            fail OptionError, 'Only one document is allowed.' if output_node.render_documents.count > 1
-            fail OptionError, 'A grammar is required.' unless input_node.grammars.count > 0
+            raise OptionError, "The renderer #{renderer} is unsupported." unless renderer == 'unimrcp' or renderer == 'native_or_unimrcp'
+            raise OptionError, "The recognizer #{recognizer} is unsupported." unless recognizer == 'unimrcp' or renderer == 'native_or_unimrcp'
+            raise OptionError, 'An SSML document is required.' unless output_node.render_documents.count > 0
+            raise OptionError, 'Only one document is allowed.' if output_node.render_documents.count > 1
+            raise OptionError, 'A grammar is required.' unless input_node.grammars.count > 0
 
             super
           end

--- a/spec/punchblock/translator/asterisk/call_spec.rb
+++ b/spec/punchblock/translator/asterisk/call_spec.rb
@@ -1231,6 +1231,17 @@ module Punchblock
               end
             end
 
+            context "when the recognizer is unimrcp and the renderer is native_or_unimrcp" do
+              let(:recognizer)  { :unimrcp }
+              let(:renderer)    { :native_or_unimrcp }
+
+              it 'should create an MRCPPrompt component and execute it asynchronously' do
+                Component::MRCPPrompt.should_receive(:new_link).once.with(command, subject).and_return mock_action
+                mock_action.async.should_receive(:execute).once
+                subject.execute_command command
+              end
+            end
+
             context "when the recognizer is unimrcp and the renderer is asterisk" do
               let(:recognizer)  { :unimrcp }
               let(:renderer)    { :asterisk }

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -162,7 +162,7 @@ module Punchblock
           end
 
           describe 'Output#renderer' do
-            [nil, :unimrcp].each do |renderer|
+            [nil, :unimrcp, :native_or_unimrcp].each do |renderer|
               context renderer.to_s do
                 let(:output_command_opts) { { renderer: renderer } }
 

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -93,23 +93,15 @@ module Punchblock
           end
 
           context 'with an invalid recognizer' do
-            let(:input_command_opts) { { recognizer: 'foobar' } }
+            [:asterisk, :foobar].each do |recognizer|
+              context "with a recognizer #{recognizer.inspect}" do
+                let(:input_command_opts) { { recognizer: recognizer } }
 
-            it "should return an error and not execute any actions" do
-              subject.execute
-              error = ProtocolError.new.setup 'option error', 'The recognizer foobar is unsupported.'
-              original_command.response(0.1).should be == error
-            end
-          end
-
-          [:asterisk].each do |recognizer|
-            context "with a recognizer #{recognizer.inspect}" do
-              let(:input_command_opts) { { recognizer: recognizer } }
-
-              it "should return an error and not execute any actions" do
-                subject.execute
-                error = ProtocolError.new.setup 'option error', "The recognizer #{recognizer} is unsupported."
-                original_command.response(0.1).should be == error
+                it "should return an error and not execute any actions" do
+                  subject.execute
+                  error = ProtocolError.new.setup 'option error', "The recognizer #{recognizer} is unsupported."
+                  original_command.response(0.1).should be == error
+                end
               end
             end
           end


### PR DESCRIPTION
Add ':native_or_unimrcp' as an input recognizer that will construct an `MRCPPrompt` rather than a `ComposedPrompt`. This is a precursor to [enabling mixed audio and TTS](https://github.com/cloudvox/apptastic/issues/144) to run with ASR enabled.
