### PR TITLE
Feature/handle new response codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Bugfix: Register/lookup components by their full URI rather than component ID since the component ID may only be unique per call (cherry-pick from mainline)
   * Bugfix: Hold back Virtus dependency to avoid API-breaking changes (cherry-pick from mainline)
   * Feature: Support `:native_or_unimrcp` renderer when using `:unimrcp` recognizer for ASR
+  * Bugfix: Support response code `'015'` from MRCP Recog Prompts (new versions of Lumenvox (correctly) respond with this in some cases)
 
 # [develop](https://github.com/adhearsion/punchblock)
   * Feature: Support RubySpeech builtin grammars on Asterisk and FreeSWITCH

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -86,7 +86,7 @@ module Punchblock
             when '000'
               nlsml = RubySpeech.parse URI.decode(@call.channel_var('RECOG_RESULT'))
               Punchblock::Component::Input::Complete::Match.new nlsml: nlsml
-            when '001'
+            when '001', '015'
               Punchblock::Component::Input::Complete::NoMatch.new
             when '002'
               Punchblock::Component::Input::Complete::NoInput.new

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -86,10 +86,13 @@ module Punchblock
             when '000'
               nlsml = RubySpeech.parse URI.decode(@call.channel_var('RECOG_RESULT'))
               Punchblock::Component::Input::Complete::Match.new nlsml: nlsml
-            when '001', '015'
+            when '001'
               Punchblock::Component::Input::Complete::NoMatch.new
             when '002'
               Punchblock::Component::Input::Complete::NoInput.new
+            when '015'
+              pb_logger.debug "Recieved a response code of 015! Call was #{@call.inspect}"
+              Punchblock::Component::Input::Complete::NoMatch.new
             end
           end
         end

--- a/spec/punchblock/translator/asterisk/component/mrcp_native_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_native_prompt_spec.rb
@@ -223,6 +223,17 @@ module Punchblock
                     end
                   end
 
+                 context 'with a 015 response code' do
+                    let(:recog_completion_cause) { '015' }
+
+                    it 'should send a nomatch complete event' do
+                      expected_complete_reason = Punchblock::Component::Input::Complete::NoMatch.new
+                      mock_call.should_receive(:execute_agi_command).and_return code: 200, result: 1
+                      subject.execute
+                      original_command.complete_event(0.1).reason.should == expected_complete_reason
+                    end
+                  end
+
                   context "when the RECOG_STATUS variable is set to 'ERROR'" do
                     let(:recog_status) { 'ERROR' }
 


### PR DESCRIPTION
Handle a response of '015' from Lumenvox. Apparently with the new version it now will send that over, as opposed to the 001/2/3 that it always used to send.

Adds some logging around that as well as a unit test.
