### PR TITLE
Feature/handle interrupted recog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Bugfix: Support passing a `'Recognition-Timeout'` flag to UniMRCP; necessary to handle shorter default settings in recognition engines like Lumenvox
   * Bugfix: Restore mainline defaults for UniMRCP settings
   * Feature: Allow passing multiple ssml documents and audiofiles to UniMRCP (requires UniMRCP revision >= r2153)
+  * Bugfix: Handle a corner case crach where a recognition request is interrupted directly after a successful recognition has completed
 
 # [develop](https://github.com/adhearsion/punchblock)
   * Feature: Support RubySpeech builtin grammars on Asterisk and FreeSWITCH

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -39,7 +39,6 @@ module Punchblock
 
           def execute_app(app, *args)
             UniMRCPApp.new(app, *args, unimrcp_app_options).execute @call
-            raise UniMRCPError if @call.channel_var('RECOG_STATUS') == 'ERROR'
           end
 
           def unimrcp_app_options
@@ -87,7 +86,11 @@ module Punchblock
           end
 
           def complete
-            if @call.channel_var('RECOG_STATUS') == 'INTERRUPTED'
+            recog_status = @call.channel_var('RECOG_STATUS')
+
+            raise UniMRCPError if recog_status == 'ERROR'
+
+            if recog_status == 'INTERRUPTED'
               return Punchblock::Component::Input::Complete::NoMatch.new
             end
 

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -87,6 +87,10 @@ module Punchblock
           end
 
           def complete
+            if @call.channel_var('RECOG_STATUS') == 'INTERRUPTED'
+              return Punchblock::Component::Input::Complete::NoMatch.new
+            end
+
             send_complete_event case @call.channel_var('RECOG_COMPLETION_CAUSE')
             when '000'
               nlsml = RubySpeech.parse URI.decode(@call.channel_var('RECOG_RESULT'))


### PR DESCRIPTION
Handle an interrupted UniMRCP request. Since the AMI Event for Hangup comes through separately we should just return a NoMatch for the recognition portion and let the rest of Punchblock deal with the Hangup event.
