### PR TITLE
add dtmf-term-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Bugfix: Restore mainline defaults for UniMRCP settings
   * Feature: Allow passing multiple ssml documents and audiofiles to UniMRCP (requires UniMRCP revision >= r2153)
   * Bugfix: Handle a corner case crach where a recognition request is interrupted directly after a successful recognition has completed
+  * Feature: Enable setting 'Dtmf-Term-Timeout' value for UniMRCP; necessary to exit sooner from successful Lumenvox recognition event
 
 # [develop](https://github.com/adhearsion/punchblock)
   * Feature: Support RubySpeech builtin grammars on Asterisk and FreeSWITCH

--- a/lib/punchblock/component/input.rb
+++ b/lib/punchblock/component/input.rb
@@ -33,6 +33,9 @@ module Punchblock
 
       # @return [Integer] Indicates (in the case of DTMF input) the amount of time between input digits which may expire before a timeout is triggered.
       attribute :inter_digit_timeout, Integer
+      #
+      # @return [Integer] Indicates (in the case of DTMF input) the amount of time between input digits which may expire before a match is returned.
+      attribute :dtmf_term_timeout, Integer
 
       # @return [Integer] Indicates the amount of time during input that recognition will occur before a timeout is triggered.
       attribute :recognition_timeout, Integer
@@ -69,6 +72,7 @@ module Punchblock
           'sensitivity' => sensitivity,
           'initial-timeout' => initial_timeout,
           'inter-digit-timeout' => inter_digit_timeout,
+          'dtmf-term-timeout' => dtmf_term_timeout,
           'recognition-timeout' => recognition_timeout
         }
       end

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -46,6 +46,7 @@ module Punchblock
               opts[:nit] = @initial_timeout if @initial_timeout > -1
               opts[:dit] = @inter_digit_timeout if @inter_digit_timeout > -1
               opts[:dttc] = input_node.terminator if input_node.terminator
+              opts[:dtt] = input_node.dtmf_term_timeout if input_node.dtmf_term_timeout
               opts[:spl] = input_node.language if input_node.language
               opts[:ct] = input_node.min_confidence if input_node.min_confidence
               opts[:sl] = input_node.sensitivity if input_node.sensitivity


### PR DESCRIPTION
allows us to set `Dtmf-Term-Timeout` header in MRCPv2 messages.
