### PR TITLE
Supervise Asterisk Translator in case of a crash

### DIFF
--- a/lib/punchblock/connection/asterisk.rb
+++ b/lib/punchblock/connection/asterisk.rb
@@ -11,7 +11,8 @@ module Punchblock
       def initialize(options = {})
         @stream_options = options.values_at(:host, :port, :username, :password)
         @ami_client = new_ami_stream
-        @translator = Translator::Asterisk.new @ami_client, self
+        @translator_supervisor = Translator::Asterisk.supervise_as :ami_translator, @ami_client, self
+        @translator = ActorHandle.new :ami_translator
         super()
       end
 
@@ -21,7 +22,7 @@ module Punchblock
       end
 
       def stop
-        translator.terminate
+        @translator_supervisor.terminate
         ami_client.terminate
       end
 
@@ -38,16 +39,14 @@ module Punchblock
       end
 
       def new_ami_stream
-        stream = RubyAMI::Stream.new(*@stream_options, ->(event) { translator.async.handle_ami_event event }, pb_logger)
-        client = (ami_client || RubyAMIStreamProxy.new(stream))
-        client.stream = stream
-        client
+        Celluloid::Actor[:ami_stream] = RubyAMI::Stream.new(*@stream_options, ->(event) { translator.async.handle_ami_event event }, pb_logger)
+        ActorHandle.new :ami_stream
       end
 
       def start_ami_client
         @ami_client = new_ami_stream unless ami_client.alive?
         ami_client.async.run
-        Celluloid::Actor.join(ami_client)
+        Celluloid::Actor.join Celluloid::Actor[:ami_stream]
       end
 
       def new_call_uri
@@ -55,17 +54,54 @@ module Punchblock
       end
     end
 
-    class RubyAMIStreamProxy
-      attr_accessor :stream
-
-      def initialize(ami)
-        @stream = ami
+    # Provides a handle to an Actor that can safely be cached/memoized without
+    # risk of that handle becoming stale from a DeadActorError.
+    #
+    # * Requirement *:
+    # The Actor must be put into the Celluloid::Actor Registry, which you are
+    # responsible for setting up yourself.
+    # @see https://github.com/celluloid/celluloid/wiki/Registry
+    # @see https://github.com/celluloid/celluloid/wiki/Supervisors
+    #
+    # Example:
+    #   require 'celluloid'
+    #   class Clumsy
+    #     include Celluloid
+    #     def initialize
+    #       puts "Clumsy ID badge # #{object_id} reporting for duty, sir!"
+    #     end
+    #   end
+    #   supervisor = Clumsy.supervise_as :clumsy
+    #   # Output: Clumsy ID badge # 2352 reporting for duty, sir!
+    #
+    #   clumsy_stale = Celluloid::Actor[:clumsy] # Don't cache clumsy_stale, he will eventually break!
+    #   clumsy_fresh = ActorHandle.new :clumsy   # Use this instead!
+    #
+    #   clumsy_fresh.async.send :no_method_kaboom # Oh no! A DeadActor!
+    #   # Output: NoMethodError: undefined method `no_method_kaboom' for #<Celluloid::ActorProxy(Clumsy:0x930)
+    #   # Output: Clumsy ID badge # 2356 reporting for duty, sir!
+    #   p clumsy_stale.alive? # Dead :(
+    #   p clumsy_fresh.alive? # Not Dead! =)
+    class ActorHandle
+      def initialize(registered_name)
+        @_registered_name = registered_name
+        fallback_handle
       end
 
       def method_missing(method, *args, &block)
-        stream.__send__(method, *args, &block)
+        fallback_handle.__send__(method, *args, &block)
       end
 
+      # Maintain a fallback handle to a Dead Actor.  Why?
+      # Why? Because Celluloid::Actor[@_registered_name] will be Nil if the
+      # Actor is terminated / de-registered.  And querying a Dead Actor is
+      # better than querying Nil.
+      def fallback_handle
+        if Celluloid::Actor[@_registered_name]
+          @stale = Celluloid::Actor[@_registered_name]
+        end
+        @stale
+      end
     end
   end
 end

--- a/spec/punchblock/connection/asterisk_spec.rb
+++ b/spec/punchblock/connection/asterisk_spec.rb
@@ -25,15 +25,7 @@ module Punchblock
       describe '#ami_client' do
         subject { connection.ami_client }
 
-        it { is_expected.to be_a RubyAMIStreamProxy }
-      end
-
-      describe '#ami_client' do
-        describe '#stream' do
-          subject { connection.ami_client.stream }
-
-          it { is_expected.to be_a RubyAMI::Stream }
-        end
+        it { is_expected.to respond_to :send_action }
       end
 
       it 'should set the connection on the translator' do


### PR DESCRIPTION
- Use a Celluloid [Supervisor](https://github.com/celluloid/celluloid/wiki/Supervisors) to ensure that the Asterisk Translator is revived if crashed for any reason.
  - Note: I was tempted to use a Celluloid Supervision Group for RubyAMI::Stream <-> Punchblock::Asterisk::Translator, but we _must_ allow the Stream to be unsupervised, as [this allows context to release](https://github.com/cloudvox/punchblock/blob/dialogtech/support/2.7.5.dt1/lib/punchblock/connection/asterisk.rb#L20) back to Adhearsion so it can conduct its [retry logic](https://github.com/cloudvox/adhearsion/blob/dialogtech/support/2.6.1/lib/adhearsion/punchblock_plugin/initializer.rb#L107)
- Inspired by RubyAMIStreamProxy, introduced ActorHandle to have a transparent interface to an Actor.
  - Taking this a step further and echoing the concerns of celluloid/celluloid#381, Stream and Translator now have handles to each other that are never stale, even if either of them becomes a Dead Actor.
  - This provides an alternative to the "kill all related objects" approach provided in standard [Celluloid Linking](https://github.com/celluloid/celluloid/wiki/Linking).

The result of this change is as follows..

The Bad...
- As before, all existing calls active in Punchblock at the time of a translator crash are lost 👎 

The Good
- Unlike before, all new calls after the crash are handled successfully! 😄 
